### PR TITLE
Adding HMS calorimeter efficiencies for Heep Coin data

### DIFF
--- a/DEF-files/PRODUCTION/KaonLT_DEF/Aero_1p011/Offline_HeeP_Coin_Cuts.def
+++ b/DEF-files/PRODUCTION/KaonLT_DEF/Aero_1p011/Offline_HeeP_Coin_Cuts.def
@@ -165,6 +165,22 @@ HMSHGCDidelec            HMSHGCShouldelec && H.cer.npeSum > 1.5
 HMSHGCCOINDide		 HMSHGCCOINShoulde && H.cer.npeSum > 1.5
 HMSHGCSINGDide		 HMSHGCSINGShoulde && H.cer.npeSum > 1.5
 
+##################
+###   HMS CAL  ###
+##################
+
+HMSCerelec         H.cer.npeSum > 1.5
+
+#HMSCALPos               H.cal.xtrack > -50 && H.cal.xtrack < 40
+
+HMSCALShouldelec         HMSGEN && HMSCerelec
+HMSCALCOINShoulde        HMSCALShouldelec && ALL_COIN_events
+HMSCALSINGShoulde        HMSCALShouldelec && HMS_event
+
+HMSCALDidelec            HMSCALShouldelec && H.cal.etottracknorm > 0.7
+HMSCALCOINDide           HMSCALCOINShoulde && H.cal.etottracknorm > 0.7
+HMSCALSINGDide           HMSCALSINGShoulde && H.cal.etottracknorm > 0.7
+
 #################
 ### SHMS BETA ###
 #################

--- a/DEF-files/PRODUCTION/KaonLT_DEF/Offline_HeeP_Coin_Cuts.def
+++ b/DEF-files/PRODUCTION/KaonLT_DEF/Offline_HeeP_Coin_Cuts.def
@@ -165,6 +165,22 @@ HMSHGCDidelec            HMSHGCShouldelec && H.cer.npeSum > 1.5
 HMSHGCCOINDide		 HMSHGCCOINShoulde && H.cer.npeSum > 1.5
 HMSHGCSINGDide		 HMSHGCSINGShoulde && H.cer.npeSum > 1.5
 
+##################
+###   HMS CAL  ###
+##################
+
+HMSCerelec         H.cer.npeSum > 1.5
+
+#HMSCALPos               H.cal.xtrack > -50 && H.cal.xtrack < 40
+
+HMSCALShouldelec         HMSGEN && HMSCerelec
+HMSCALCOINShoulde        HMSCALShouldelec && ALL_COIN_events
+HMSCALSINGShoulde        HMSCALShouldelec && HMS_event
+
+HMSCALDidelec            HMSCALShouldelec && H.cal.etottracknorm > 0.7
+HMSCALCOINDide           HMSCALCOINShoulde && H.cal.etottracknorm > 0.7
+HMSCALSINGDide           HMSCALSINGShoulde && H.cal.etottracknorm > 0.7
+
 #################
 ### SHMS BETA ###
 #################

--- a/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_10p6_GeV.param
+++ b/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_10p6_GeV.param
@@ -61,16 +61,16 @@ hcer_debug_adc = 1
 
 
 ;; The following offsets are finalized based on G. Huber and R. Trotta Study (Fall 2023)
-:: Added by A. Usman on 28/11/2023
+;; Added by A. Usman on 28/11/2023
 
 ;; HMS Centeral Momentum (P) Offset (10.6 GeV Kaon-LT Data)
 
 hpcentral_offset = -0.100
 
-:: HMS Central Angle (Theta) Offset (10.6 GeV Kaon-LT Data)
+;; HMS Central Angle (Theta) Offset (10.6 GeV Kaon-LT Data)
 
 hthetacentral_offset = 0.0010
 
-:: HMS Out-of-Plane (OOP) Offset (10.6 GeV Kaon-LT Data)
+;; HMS Out-of-Plane (OOP) Offset (10.6 GeV Kaon-LT Data)
 
 h_oopcentral_offset = 0.00251

--- a/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_3p8_GeV.param
+++ b/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_3p8_GeV.param
@@ -61,16 +61,16 @@ hcer_debug_adc = 1
 
 
 ;; The following offsets are finalized based on G. Huber and R. Trotta Study (Fall 2023)
-:: Added by A. Usman on 28/11/2023
+;; Added by A. Usman on 28/11/2023
 
 ;; HMS Centeral Momentum (P) Offset (3.8 GeV Kaon-LT Data)
 
 hpcentral_offset = -0.100
 
-:: HMS Central Angle (Theta) Offset (3.8 GeV Kaon-LT Data)
+;; HMS Central Angle (Theta) Offset (3.8 GeV Kaon-LT Data)
 
 hthetacentral_offset = 0.0010
 
-:: HMS Out-of-Plane (OOP) Offset (3.8 GeV Kaon-LT Data)
+;; HMS Out-of-Plane (OOP) Offset (3.8 GeV Kaon-LT Data)
 
 h_oopcentral_offset = 0.00251

--- a/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_4p9_GeV.param
+++ b/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_4p9_GeV.param
@@ -61,16 +61,16 @@ hcer_debug_adc = 1
 
 
 ;; The following offsets are finalized based on G. Huber and R. Trotta Study (Fall 2023)
-:: Added by A. Usman on 28/11/2023
+;; Added by A. Usman on 28/11/2023
 
 ;; HMS Centeral Momentum (P) Offset (4.9 GeV Kaon-LT Data)
 
 hpcentral_offset = -0.100
 
-:: HMS Central Angle (Theta) Offset (4.9 GeV Kaon-LT Data)
+;; HMS Central Angle (Theta) Offset (4.9 GeV Kaon-LT Data)
 
 hthetacentral_offset = 0.0010
 
-:: HMS Out-of-Plane (OOP) Offset (4.9 GeV Kaon-LT Data)
+;; HMS Out-of-Plane (OOP) Offset (4.9 GeV Kaon-LT Data)
 
 h_oopcentral_offset = 0.00251

--- a/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_6p2_GeV.param
+++ b/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_6p2_GeV.param
@@ -61,16 +61,16 @@ hcer_debug_adc = 1
 
 
 ;; The following offsets are finalized based on G. Huber and R. Trotta Study (Fall 2023)
-:: Added by A. Usman on 28/11/2023
+;; Added by A. Usman on 28/11/2023
 
 ;; HMS Centeral Momentum (P) Offset (6.2 GeV Kaon-LT Data)
 
 hpcentral_offset = -0.100
 
-:: HMS Central Angle (Theta) Offset (6.2 GeV Kaon-LT Data)
+;; HMS Central Angle (Theta) Offset (6.2 GeV Kaon-LT Data)
 
 hthetacentral_offset = 0.0010
 
-:: HMS Out-of-Plane (OOP) Offset (6.2 GeV Kaon-LT Data)
+;; HMS Out-of-Plane (OOP) Offset (6.2 GeV Kaon-LT Data)
 
 h_oopcentral_offset = 0.00251

--- a/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_8p2_GeV.param
+++ b/PARAM/HMS/GEN/KaonLT_PARAM/hmsflags_8p2_GeV.param
@@ -61,16 +61,16 @@ hcer_debug_adc = 1
 
 
 ;; The following offsets are finalized based on G. Huber and R. Trotta Study (Fall 2023)
-:: Added by A. Usman on 28/11/2023
+;; Added by A. Usman on 28/11/2023
 
 ;; HMS Centeral Momentum (P) Offset (8.2 GeV Kaon-LT Data)
 
 hpcentral_offset = -0.100
 
-:: HMS Central Angle (Theta) Offset (8.2 GeV Kaon-LT Data)
+;; HMS Central Angle (Theta) Offset (8.2 GeV Kaon-LT Data)
 
 hthetacentral_offset = 0.0010
 
-:: HMS Out-of-Plane (OOP) Offset (8.2 GeV Kaon-LT Data)
+;; HMS Out-of-Plane (OOP) Offset (8.2 GeV Kaon-LT Data)
 
 h_oopcentral_offset = 0.00251

--- a/PARAM/SHMS/GEN/KaonLT_PARAM/shmsflags.param
+++ b/PARAM/SHMS/GEN/KaonLT_PARAM/shmsflags.param
@@ -30,7 +30,7 @@ pphi_offset = 0.0; (rad) hxp_tar = hxp_tar + hphi_offset
 
 ;; The following offsets are applied to the central kinematic variables
 ;;      ptheta_lab=htheta_lab + pthetacentral_offset/degree
-:;pthetacentral_offset  = 0.0 ;     (rad)   For no offset data
+;;pthetacentral_offset  = 0.0 ;     (rad)   For no offset data
 ;;pthetacentral_offset = 0.0 ;     (rad)   New offset for 3.6 & 3.9 GeV
 ;;pthetacentral_offset =  1.0e-3  ;  (rad)   New offset for 4.5 GeV
 ;;pthetacentral_offset = 1.2e-3  ; (rad)   New offset for 4.9 GeV
@@ -41,23 +41,23 @@ pphi_offset = 0.0; (rad) hxp_tar = hxp_tar + hphi_offset
 ;;ppcentral_offset = -0.4      ; Old offset
 ;;ppcentral_offset = 0.0        ; For no offset data
 ;;ppcentral_offset = -0.0894   ; New offset for 3.9 & 3.6 GeV data
-:ppcentral_offset = -0.25        ; just to test
+;ppcentral_offset = -0.25        ; just to test
 ;;ppcentral_offset = -0.2937     ; New offset for 4.5 GeV data
 ;;ppcentral_offset = -0.312    ; New offset for 4.9 GeV data
 ;ppcentral_offset = -0.450     ; New offset for 2.7 GeV data
 
 
 ;; The following offsets are finalized based on G. Huber and R. Trotta Study (Fall 2023)
-:: Added by A. Usman on 28/11/2023
+;; Added by A. Usman on 28/11/2023
 
 ;; SHMS Centeral Momentum (P) Offset (All Kaon-LT Data)
 
 ppcentral_offset = -0.200
 
-:: SHMS Central Angle (Theta) Offset (All Kaon-LT Data)
+;; SHMS Central Angle (Theta) Offset (All Kaon-LT Data)
 
 pthetacentral_offset = 0.0011
 
-:: SHMS Out-of-Plane (Phi) Offset (All Kaon-LT Data)
+;; SHMS Out-of-Plane (Phi) Offset (All Kaon-LT Data)
 
 p_oopcentral_offset = -0.00011

--- a/TEMPLATES/COIN/PRODUCTION/KaonLT_TEMP/KaonLT_Offline_HEEP_Coin.template
+++ b/TEMPLATES/COIN/PRODUCTION/KaonLT_TEMP/KaonLT_Offline_HEEP_Coin.template
@@ -247,6 +247,19 @@ hB       Counts: {H.cal.stat_trksum2} eff : {H.cal.stat_hitsum2 / H.cal.stat_trk
 hC       Counts: {H.cal.stat_trksum3} eff : {H.cal.stat_hitsum3 / H.cal.stat_trksum3}
 hD       Counts: {H.cal.stat_trksum4} eff : {H.cal.stat_hitsum4 / H.cal.stat_trksum4}
 
+KLT_HMS_ALL_Elec_Cal_Did            :   {HMSCALDidelec.npassed}
+KLT_HMS_ALL_Elec_Cal_Should         :   {HMSCALShouldelec.npassed}
+KLT_HMS_COIN_Elec_Cal_Did           :   {HMSCALCOINDide.npassed}
+KLT_HMS_COIN_Elec_Cal_Should        :   {HMSCALCOINShoulde.npassed}
+KLT_HMS_SING_Elec_Cal_Did           :   {HMSCALSINGDide.npassed}
+KLT_HMS_SING_Elec_Cal_Should        :   {HMSCALSINGShoulde.npassed}
+
+KLT_HMS_Cal_ALL_Elec_Eff            :   {HMSCALDidelec.npassed / (HMSCALShouldelec.npassed+0.0001):%8.4f} +- {(sqrt((((HMSCALShouldelec.npassed)*(HMSCALDidelec.npassed))-((HMSCALDidelec.npassed)*(HMSCALDidelec.npassed))) / ((HMSCALShouldelec.npassed)*(HMSCALShouldelec.npassed)*(HMSCALShouldelec.npassed)))):%8.4f}
+
+KLT_HMS_Cal_COIN_Elec_Eff           :   {HMSCALCOINDide.npassed / (HMSCALCOINShoulde.npassed+0.0001):%8.4f} +- {(sqrt((((HMSCALCOINShoulde.npassed)*(HMSCALCOINDide.npassed))-((HMSCALCOINDide.npassed)*(HMSCALCOINDide.npassed))) / ((HMSCALCOINShoulde.npassed)*(HMSCALCOINShoulde.npassed)*(HMSCALCOINShoulde.npassed)))):%8.4f}
+
+KLT_HMS_Cal_SING_Elec_Eff           :   {HMSCALSINGDide.npassed / (HMSCALSINGShoulde.npassed+0.0001):%8.4f} +- {(sqrt((((HMSCALSINGShoulde.npassed)*(HMSCALSINGDide.npassed))-((HMSCALSINGDide.npassed)*(HMSCALSINGDide.npassed))) / ((HMSCALSINGShoulde.npassed)*(HMSCALSINGShoulde.npassed)*(HMSCALSINGShoulde.npassed)))):%8.4f}
+
 ===================
 == Triggers Info ==
 ===================


### PR DESCRIPTION
The HMS calorimeter efficiency calculations already exist for physics production data but it was missing for Heep Coin data. Please note that this efficiency should only be used for HMS momentum below cherenkov threshold.